### PR TITLE
Refactor TIME_ATTACK via time_attack.hpp and harden Docker scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,17 @@ set(CMAKE_CUDA_ARCHITECTURES "${CLAST_CUDA_ARCHITECTURES}" CACHE STRING
 
 project(CLAST LANGUAGES CXX CUDA)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_EXTENSIONS OFF)
 
 find_package(CUDAToolkit REQUIRED)
 find_package(Boost REQUIRED)
 include(CTest)
+
+option(CLAST_ENABLE_TIME_ATTACK "Compile clast with TIME_ATTACK (verbose GPU timing output)" OFF)
 
 set(CLAST_SOURCES
   src/device/CDeviceHashTable.cu
@@ -57,6 +59,9 @@ target_include_directories(clast PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+if(CLAST_ENABLE_TIME_ATTACK)
+  target_compile_definitions(clast PRIVATE TIME_ATTACK)
+endif()
 target_link_libraries(clast PRIVATE CUDA::cudart)
 set_target_properties(clast PROPERTIES
   CUDA_SEPARABLE_COMPILATION ON

--- a/README.md
+++ b/README.md
@@ -40,29 +40,41 @@ container based on `nvidia/cuda:12.4.1-devel-ubuntu22.04`.
 
 ### Option 2: Docker Scripts
 
-Build the development image:
+Build the development image (required once, from the repository root):
 
 ```bash
 docker build -t clast-cuda-dev .devcontainer
 ```
 
-Compile CLAST:
+Compile CLAST (Ninja, artifacts under `build/` on the host; default `BUILD_TESTING` is
+`Off` in this script so `cmake` does not need to fetch GoogleTest; set
+`CLAST_CMAKE_BUILD_TESTING=On` if you also want the unit test binary in one step):
 
 ```bash
 ./scripts/docker-build.sh
 ```
 
-Run the current minimal test suite:
+Run the current minimal test suite (uses `build/`; first run needs network to
+fetch GoogleTest for configuration):
 
 ```bash
 ./scripts/docker-test.sh
 ```
 
-Run the tiny smoke test:
+Run the tiny smoke test (requires a GPU; uses `CLAST_DOCKER_GPU_FLAG` if you
+need to change `docker run` GPU options):
 
 ```bash
 ./scripts/docker-smoke.sh
 ```
+
+On **Windows (PowerShell)**, the `.sh` files are not run by bash by default, so
+use the wrappers: `.\scripts\docker-build.ps1`, `.\scripts\docker-test.ps1`, or
+`.\scripts\docker-smoke.ps1`. The wrapper **prefers Git for Windows’ `bash`**
+over WSL (Docker works with either; WSL can report `Wsl/Service/E_UNEXPECTED`
+while Git bash is fine). To try WSL first instead, set
+`$env:CLAST_POWERSHELL_BASH_ORDER = "wsl-first"`, or run
+`"C:\Program Files\Git\bin\bash.exe" ./scripts/docker-build.sh` from the repo root.
 
 If the runtime environment has no GPU driver, the smoke script will fail with a
 CUDA driver/runtime mismatch. Compilation should still succeed.

--- a/scripts/docker-bash.ps1
+++ b/scripts/docker-bash.ps1
@@ -1,0 +1,42 @@
+#Requires -Version 5.1
+# Git bash (優先) または WSL で docker-*.sh を実行。CLAST_POWERSHELL_BASH_ORDER=wsl-first で WSL 優先。
+param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [ValidateSet('build', 'test', 'smoke')]
+  [string] $Action
+)
+$ErrorActionPreference = 'Stop'
+$sh = switch ($Action) {
+  'build' { 'docker-build.sh' }
+  'test'  { 'docker-test.sh' }
+  'smoke' { 'docker-smoke.sh' }
+}
+$repo = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if (-not (Test-Path (Join-Path $PSScriptRoot $sh))) { throw "Missing: scripts\$sh" }
+$gitBash = @(
+  "${env:ProgramFiles}\Git\usr\bin\bash.exe",
+  "${env:ProgramFiles}\Git\bin\bash.exe",
+  "$env:LocalAppData\Programs\Git\usr\bin\bash.exe"
+) | Where-Object { Test-Path $_ } | Select-Object -First 1
+$wslFirst = $env:CLAST_POWERSHELL_BASH_ORDER -eq "wsl-first"
+Push-Location $repo
+$rel = "./scripts/" + $sh
+function Invoke-WithBash {
+  param([string]$BashPath)
+  & $BashPath -l $rel
+  if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+function Invoke-WslBash {
+  wsl.exe bash -l $rel
+  if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+try {
+  if ($wslFirst) {
+    if (Get-Command wsl.exe -ErrorAction SilentlyContinue) { Invoke-WslBash; return }
+    if ($gitBash) { Invoke-WithBash $gitBash; return }
+  } else {
+    if ($gitBash) { Invoke-WithBash $gitBash; return }
+    if (Get-Command wsl.exe -ErrorAction SilentlyContinue) { Invoke-WslBash; return }
+  }
+  throw "Install Git for Windows (https://git-scm.com) or WSL, or run: wsl.exe bash $rel"
+} finally { Pop-Location }

--- a/scripts/docker-build.ps1
+++ b/scripts/docker-build.ps1
@@ -1,0 +1,4 @@
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+& (Join-Path $PSScriptRoot 'docker-bash.ps1') -Action build
+exit $LASTEXITCODE

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,13 +1,27 @@
 #!/usr/bin/env bash
+# Build clast only; use docker-test.sh for ctest. Default BUILD_TESTING=Off (no GTest fetch).
 set -euo pipefail
 
 IMAGE="${CLAST_DOCKER_IMAGE:-clast-cuda-dev}"
 JOBS="${CLAST_BUILD_JOBS:-4}"
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAST_CMAKE_BUILD_TESTING="${CLAST_CMAKE_BUILD_TESTING:-Off}"
+BUILD_DIR="${CLAST_CMAKE_BUILD_DIR:-build}"
+_s=${BASH_SOURCE[0]}
+case $_s in
+  */*) _s=${_s%/*} ;;
+  *) _s=. ;;
+esac
+_s=$(cd -- "$_s" && pwd)
+# shellcheck source=docker-common.sh
+source "$_s/docker-common.sh"
+unset _s
 
-docker run --rm \
-  -e CLAST_BUILD_JOBS="${JOBS}" \
-  -v "${ROOT_DIR}:/workspaces/CLAST" \
-  -w /workspaces/CLAST \
+docker run --rm -i "${DOCKER_TT[@]}" \
+  -v "${DOCKER_BIND_SRC}:/workspaces/CLAST" \
   "${IMAGE}" \
-  bash -lc 'cmake -S . -B /tmp/clast-build -G Ninja && cmake --build /tmp/clast-build -j "${CLAST_BUILD_JOBS}"'
+  bash -c "set -euo pipefail
+printf '%s\n' \"[clast] cmake configure -> ${BUILD_DIR} (BUILD_TESTING=${CLAST_CMAKE_BUILD_TESTING})...\"
+cmake -S . -B \"${BUILD_DIR}\" -G Ninja -DCLAST_CUDA_ARCHITECTURES=75 -DBUILD_TESTING=${CLAST_CMAKE_BUILD_TESTING} &&
+printf '%s\n' \"[clast] cmake --build -j${JOBS}...\" &&
+cmake --build \"${BUILD_DIR}\" -j ${JOBS} &&
+printf '%s\n' \"[clast] ok: /workspaces/CLAST/${BUILD_DIR}/clast\""

--- a/scripts/docker-common.sh
+++ b/scripts/docker-common.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+# Sourced from docker-*.sh only. BASH_SOURCE[0] = this file; BASH_SOURCE[1] = caller.
+if [[ ${#BASH_SOURCE[@]} -lt 2 ]]; then
+  echo "error: source docker-common.sh from docker-*.sh" >&2
+  exit 1
+fi
+if [[ -z "${IMAGE:-}" ]]; then
+  echo "error: IMAGE must be set before sourcing docker-common.sh" >&2
+  exit 1
+fi
+_entry=${BASH_SOURCE[1]}
+_s=${_entry}
+case $_s in
+  */*) _s=${_s%/*} ;;
+  *) _s=. ;;
+esac
+ROOT_DIR="$(cd "$_s/.." && pwd)"
+export MSYS2_ARG_CONV_EXCL="${MSYS2_ARG_CONV_EXCL:+$MSYS2_ARG_CONV_EXCL:}docker"
+if command -v cygpath >/dev/null 2>&1; then
+  DOCKER_BIND_SRC="$(cygpath -w "$ROOT_DIR")"
+else
+  DOCKER_BIND_SRC="$ROOT_DIR"
+fi
+DOCKER_TT=()
+if [ -t 1 ]; then
+  DOCKER_TT=(-t)
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker is not in PATH" >&2
+  exit 1
+fi
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+  echo "error: Docker image \"${IMAGE}\" not found. Build: docker build -t ${IMAGE} .devcontainer" >&2
+  exit 1
+fi
+unset _entry _s

--- a/scripts/docker-smoke.ps1
+++ b/scripts/docker-smoke.ps1
@@ -1,0 +1,4 @@
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+& (Join-Path $PSScriptRoot 'docker-bash.ps1') -Action smoke
+exit $LASTEXITCODE

--- a/scripts/docker-smoke.sh
+++ b/scripts/docker-smoke.sh
@@ -2,14 +2,27 @@
 set -euo pipefail
 
 IMAGE="${CLAST_DOCKER_IMAGE:-clast-cuda-dev}"
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OUTPUT_PATH="${CLAST_SMOKE_OUTPUT:-/tmp/clast-smoke.tsv}"
+JOBS="${CLAST_BUILD_JOBS:-4}"
+BUILD_DIR="${CLAST_CMAKE_BUILD_DIR:-build}"
+_s=${BASH_SOURCE[0]}
+case $_s in
+  */*) _s=${_s%/*} ;;
+  *) _s=. ;;
+esac
+_s=$(cd -- "$_s" && pwd)
+# shellcheck source=docker-common.sh
+source "$_s/docker-common.sh"
+unset _s
+OUTPUT_PATH="${CLAST_SMOKE_OUTPUT:-build/clast-smoke.tsv}"
 GPU_FLAG="${CLAST_DOCKER_GPU_FLAG:---gpus all}"
 
-docker run --rm ${GPU_FLAG} \
-  -v "${ROOT_DIR}:/workspaces/CLAST" \
-  -w /workspaces/CLAST \
+docker run --rm -i "${DOCKER_TT[@]}" ${GPU_FLAG} \
+  -v "${DOCKER_BIND_SRC}:/workspaces/CLAST" \
   "${IMAGE}" \
-  bash -lc "cmake -S . -B /tmp/clast-build -G Ninja >/tmp/configure.log && \
-    cmake --build /tmp/clast-build -j 4 >/tmp/build.log && \
-    /tmp/clast-build/clast -t tests/smoke/target.fa -q tests/smoke/query.fa -o \"${OUTPUT_PATH}\""
+  bash -c "set -euo pipefail
+printf '%s\n' \"[clast] configure + build (no tests) in ${BUILD_DIR}...\"
+cmake -S . -B \"${BUILD_DIR}\" -G Ninja -DCLAST_CUDA_ARCHITECTURES=75 -DBUILD_TESTING=Off &&
+cmake --build \"${BUILD_DIR}\" -j ${JOBS} &&
+printf '%s\n' \"[clast] smoke: writing ${OUTPUT_PATH}...\"
+\"${BUILD_DIR}/clast\" -t tests/smoke/target.fa -q tests/smoke/query.fa -o \"${OUTPUT_PATH}\"
+printf '%s\n' \"[clast] ok: /workspaces/CLAST/${OUTPUT_PATH}\""

--- a/scripts/docker-test.ps1
+++ b/scripts/docker-test.ps1
@@ -1,0 +1,4 @@
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+& (Join-Path $PSScriptRoot 'docker-bash.ps1') -Action test
+exit $LASTEXITCODE

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -3,13 +3,22 @@ set -euo pipefail
 
 IMAGE="${CLAST_DOCKER_IMAGE:-clast-cuda-dev}"
 JOBS="${CLAST_BUILD_JOBS:-4}"
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${CLAST_CMAKE_BUILD_DIR:-build}"
+_s=${BASH_SOURCE[0]}
+case $_s in
+  */*) _s=${_s%/*} ;;
+  *) _s=. ;;
+esac
+_s=$(cd -- "$_s" && pwd)
+# shellcheck source=docker-common.sh
+source "$_s/docker-common.sh"
+unset _s
 
-docker run --rm \
-  -e CLAST_BUILD_JOBS="${JOBS}" \
-  -v "${ROOT_DIR}:/workspaces/CLAST" \
-  -w /workspaces/CLAST \
+docker run --rm -i "${DOCKER_TT[@]}" \
+  -v "${DOCKER_BIND_SRC}:/workspaces/CLAST" \
   "${IMAGE}" \
-  bash -lc 'cmake -S . -B /tmp/clast-build -G Ninja -DCLAST_CUDA_ARCHITECTURES=75 && \
-    cmake --build /tmp/clast-build -j "${CLAST_BUILD_JOBS}" && \
-    ctest --test-dir /tmp/clast-build --output-on-failure'
+  bash -c "set -euo pipefail
+printf '%s\n' \"[clast] cmake (tests on) + build + ctest in ${BUILD_DIR}...\"
+cmake -S . -B \"${BUILD_DIR}\" -G Ninja -DCLAST_CUDA_ARCHITECTURES=75 &&
+cmake --build \"${BUILD_DIR}\" -j ${JOBS} &&
+ctest --test-dir \"${BUILD_DIR}\" --output-on-failure"

--- a/src/cli/main.cu
+++ b/src/cli/main.cu
@@ -1,15 +1,53 @@
 #include "util/common.hpp"
+#include "util/time_attack.hpp"
 
 #include "host/CFASTALoader.hpp"
 #include "host/CHostFASTA.hpp"
 #include "host/CHostMapper.cuh"
 #include "host/CHostSetting.cuh"
 
+#include <ctime>
 #include <iostream>
 #include <fstream>
 #include <vector>
 
 #include "test_support/CTest.cuh"
+
+namespace {
+
+std::vector<CHostFASTA> loadQueryChunk(CFASTALoader& loader, int partIndex) {
+	std::vector<CHostFASTA> out;
+	time_attack::runLabeledPrefix(
+			[partIndex](std::ostream& os) { os << std::endl << "...Loading FASTA data in ./query (part:" << partIndex << ")"; },
+			"...finished.",
+			[&] { loader.loadFASTA(out); });
+	return out;
+}
+
+std::vector<CHostFASTA> loadTargetChunk(CFASTALoader& loader, int partIndex) {
+	std::vector<CHostFASTA> out;
+	time_attack::runLabeledPrefix(
+			[partIndex](std::ostream& os) { os << std::endl << "...Loading FASTA data in ./target(part:" << partIndex << ")"; },
+			"...finished.",
+			[&] { loader.loadFASTA(out); });
+	return out;
+}
+
+void sleepForGpuCoolDown(int sleepTimeSec) {
+	std::cout
+			<< " CLAST is now sleeping in order to make GPU cool." << std::endl
+			<< " It will cost " << sleepTimeSec << " sec." << std::endl;
+	const clock_t s = clock();
+	clock_t c;
+	do {
+		if ((c = clock()) == static_cast<clock_t>(-1)) {
+			break;
+		}
+	} while ((1000UL * (c - s) / CLOCKS_PER_SEC) <= (static_cast<unsigned long>(sleepTimeSec) * 1000UL));
+	std::cout << " ...finished." << std::endl << std::endl;
+}
+
+}  // namespace
 
 /******************************************* main function ***********************************************/
 
@@ -42,45 +80,14 @@ int main(const int argc, const char** argv) {
 			setting.getQueryRAMSize() / 2, // magic number "2" ... "+" query and "-" query. 
 			"query");
 	for(int i = 0; queryFASTALoader.getFileIndex() != -1; ++i) {
-		#ifdef TIME_ATTACK
-			float elapsed_time_ms_2=0.0f;
-			cudaEvent_t start_2, stop_2;
-			cudaEventCreate( &start_2 );
-			cudaEventCreate( &stop_2  );
-			cudaEventRecord( start_2, 0 );
-			std::cout << std::endl << "...Loading FASTA data in ./query (part:" << i << ")";
-		#endif /* TIME_ATTACK */
-		std::vector<CHostFASTA> queryFASTA;
-		queryFASTALoader.loadFASTA(queryFASTA);
-		#ifdef TIME_ATTACK
-			std::cout << "...finished.";
-			cudaEventRecord( stop_2, 0 );
-			cudaEventSynchronize( stop_2 );
-			cudaEventElapsedTime( &elapsed_time_ms_2, start_2, stop_2 );
-			std::cout << " (costs " << elapsed_time_ms_2 << "ms)" << std::endl;
-		#endif /* TIME_ATTACK */
+		const std::vector<CHostFASTA> queryFASTA = loadQueryChunk(queryFASTALoader, i);
 		CHostResultHolder holder(queryFASTA);
 		CFASTALoader targetFASTALoader(
 				setting.getTargetFileArray(),
 				setting.getTargetRAMSize(),
 				"target");
 		for(int j = 0; targetFASTALoader.getFileIndex() != -1; ++j) {
-			#ifdef TIME_ATTACK
-				cudaEventCreate( &start_2 );
-				cudaEventCreate( &stop_2  );
-				cudaEventRecord( start_2, 0 );
-				std::cout << std::endl << "...Loading FASTA data in ./target(part:" << j << ")";
-			#endif /* TIME_ATTACK */
-			/* load target */
-			std::vector<CHostFASTA> targetFASTA;
-			targetFASTALoader.loadFASTA(targetFASTA);
-			#ifdef TIME_ATTACK
-				std::cout << "...finished.";
-				cudaEventRecord( stop_2, 0 );
-				cudaEventSynchronize( stop_2 );
-				cudaEventElapsedTime( &elapsed_time_ms_2, start_2, stop_2 );
-				std::cout << " (costs " << elapsed_time_ms_2 << "ms)" << std::endl;
-			#endif /* TIME_ATTACK */
+			const std::vector<CHostFASTA> targetFASTA = loadTargetChunk(targetFASTALoader, j);
 			/* mapping */
 			CHostMapper mapper(setting);
 			mapper.addTarget(targetFASTA);
@@ -91,16 +98,7 @@ int main(const int argc, const char** argv) {
 		holder.fixResult();
 		holder.printResult(setting.getNumberOfOutput(), setting.getOutputFile());
 		std::cout << " ...finished." << std::endl;
-		/* wait to cool down */
-		std::cout
-				<< " CLAST is now sleeping in order to make GPU cool." << std::endl
-				<< " It will cost " << setting.getSleepTime() << " sec." << std::endl;
-		clock_t  s = clock();
-		clock_t  c;
-		do {
-			if ((c = clock()) == static_cast<clock_t>(-1)) { break; }
-		} while ((1000UL * (c - s) / CLOCKS_PER_SEC) <= (setting.getSleepTime() * 1000UL));
-		std::cout << " ...finished." << std::endl << std::endl;
+		sleepForGpuCoolDown(setting.getSleepTime());
 	}
 	std::cout << std::endl << " << Searching end >>" << std::endl;
 	cudaEventRecord( stop, 0 );

--- a/src/device/CDeviceHitList.cu
+++ b/src/device/CDeviceHitList.cu
@@ -17,6 +17,8 @@
 #include <thrust/transform.h>
 
 #include "util/common.hpp"
+#include "util/time_attack.hpp"
+#include <iostream>
 
 #ifdef MODE_TEST
 #include "test_support/CTest.cuh"
@@ -29,7 +31,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
 
-void deleteHits_duplicateResult(
+void removeDuplicateResultHits(
 		thrust::device_vector<int>& targetIDArray,
 		thrust::device_vector<int>& targetIndexArray,
 		thrust::device_vector<int>& queryIDArray,
@@ -39,16 +41,8 @@ void deleteHits_duplicateResult(
 		thrust::device_vector<int>& matchNumArray,
 		thrust::device_vector<int>& scoreArray,
 		thrust::device_vector<double>& evalueArray) {
-        #ifdef TIME_ATTACK
-                float elapsed_time_ms=0.0f;
-                cudaEvent_t start, stop;
-                cudaEventCreate( &start );
-                cudaEventCreate( &stop  );
-                cudaEventRecord( start, 0 );
-                std::cout << "  ...deleting duplicate hits";
-        #endif /* TIME_ATTACK */
 	using namespace thrust;
-	if(targetIDArray.size() > 1) {
+	if (targetIDArray.size() > 1) {
 		/* do remove */
 		const int new_size = remove_if(
 				make_zip_iterator(
@@ -115,19 +109,107 @@ void deleteHits_duplicateResult(
 		scoreArray      .resize(new_size);
 		evalueArray     .resize(new_size);
 	}
-        #ifdef TIME_ATTACK
-                std::cout << "...............................finished.";
-                cudaEventRecord( stop, 0 );
-                cudaEventSynchronize( stop );
-                cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-                std::cout
-                                << " (costs " << elapsed_time_ms << "ms) "
-                                << targetIDArray.size() << " hits found."
-                                << std::endl;
-        #endif /* TIME_ATTACK */
+}
+
+void deleteHits_duplicateResult(
+		thrust::device_vector<int>& targetIDArray,
+		thrust::device_vector<int>& targetIndexArray,
+		thrust::device_vector<int>& queryIDArray,
+		thrust::device_vector<int>& queryIndexArray,
+		thrust::device_vector<int>& tHitLengthArray,
+		thrust::device_vector<int>& qHitLengthArray,
+		thrust::device_vector<int>& matchNumArray,
+		thrust::device_vector<int>& scoreArray,
+		thrust::device_vector<double>& evalueArray) {
+	time_attack::runLabeledWithSuffix(
+			"  ...deleting duplicate hits", "...............................finished.",
+			[&] {
+				removeDuplicateResultHits(
+						targetIDArray,
+						targetIndexArray,
+						queryIDArray,
+						queryIndexArray,
+						tHitLengthArray,
+						qHitLengthArray,
+						matchNumArray,
+						scoreArray,
+						evalueArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << targetIDArray.size() << " hits found." << std::endl;
+			});
 }
 
 /********************************* non class functions ***********************************/
+
+void appendUnExactMatchResults(
+		const thrust::device_vector<int>& add_targetIDArray,
+		const thrust::device_vector<int>& add_targetIndexArray,
+		const thrust::device_vector<int>& add_queryIDArray,
+		const thrust::device_vector<int>& add_queryIndexArray,
+		const thrust::device_vector<int>& add_tHitLengthArray,
+		const thrust::device_vector<int>& add_qHitLengthArray,
+		const thrust::device_vector<int>& add_matchNumArray,
+		const thrust::device_vector<int>& add_scoreArray,
+		const thrust::device_vector<double>& add_evalueArray,
+		thrust::device_vector<int>& targetIDArray,
+		thrust::device_vector<int>& targetIndexArray,
+		thrust::device_vector<int>& queryIDArray,
+		thrust::device_vector<int>& queryIndexArray,
+		thrust::device_vector<int>& tHitLengthArray,
+		thrust::device_vector<int>& qHitLengthArray,
+		thrust::device_vector<int>& matchNumArray,
+		thrust::device_vector<int>& scoreArray,
+		thrust::device_vector<double>& evalueArray) {
+	using namespace thrust;
+	const int oldResultSize = targetIDArray.size();
+	const int newResultSize = oldResultSize + add_targetIDArray.size();
+	targetIDArray.resize(newResultSize);
+	targetIndexArray.resize(newResultSize);
+	queryIDArray.resize(newResultSize);
+	queryIndexArray.resize(newResultSize);
+	tHitLengthArray.resize(newResultSize);
+	qHitLengthArray.resize(newResultSize);
+	matchNumArray.resize(newResultSize);
+	scoreArray.resize(newResultSize);
+	evalueArray.resize(newResultSize);
+	copy(
+			add_targetIDArray.begin(),
+			add_targetIDArray.end(),
+			targetIDArray.begin() + oldResultSize);
+	copy(
+			add_targetIndexArray.begin(),
+			add_targetIndexArray.end(),
+			targetIndexArray.begin() + oldResultSize);
+	copy(
+			add_queryIDArray.begin(),
+			add_queryIDArray.end(),
+			queryIDArray.begin() + oldResultSize);
+	copy(
+			add_queryIndexArray.begin(),
+			add_queryIndexArray.end(),
+			queryIndexArray.begin() + oldResultSize);
+	copy(
+			add_tHitLengthArray.begin(),
+			add_tHitLengthArray.end(),
+			tHitLengthArray.begin() + oldResultSize);
+	copy(
+			add_qHitLengthArray.begin(),
+			add_qHitLengthArray.end(),
+			qHitLengthArray.begin() + oldResultSize);
+	copy(
+			add_matchNumArray.begin(),
+			add_matchNumArray.end(),
+			matchNumArray.begin() + oldResultSize);
+	copy(
+			add_scoreArray.begin(),
+			add_scoreArray.end(),
+			scoreArray.begin() + oldResultSize);
+	copy(
+			add_evalueArray.begin(),
+			add_evalueArray.end(),
+			evalueArray.begin() + oldResultSize);
+}
 
 void addResult(
 		const thrust::device_vector<int>& add_targetIDArray,
@@ -148,80 +230,32 @@ void addResult(
 		thrust::device_vector<int>& matchNumArray,
 		thrust::device_vector<int>& scoreArray,
 		thrust::device_vector<double>& evalueArray) {
-        #ifdef TIME_ATTACK
-                float elapsed_time_ms=0.0f;
-                cudaEvent_t start, stop;
-                cudaEventCreate( &start );
-                cudaEventCreate( &stop  );
-                cudaEventRecord( start, 0 );
-                std::cout << "  ...writing un-exact matches";
-        #endif /* TIME_ATTACK */
-	const int oldResultSize = targetIDArray.size();
-	const int newResultSize = oldResultSize + add_targetIDArray.size();
-	targetIDArray   .resize(newResultSize);
-	targetIndexArray.resize(newResultSize);
-	queryIDArray    .resize(newResultSize);
-	queryIndexArray .resize(newResultSize);
-	tHitLengthArray .resize(newResultSize);
-	qHitLengthArray .resize(newResultSize);
-	matchNumArray   .resize(newResultSize);
-	scoreArray      .resize(newResultSize);
-	evalueArray     .resize(newResultSize);
-	copy(
-			add_targetIDArray.begin(),
-			add_targetIDArray.end(),
-			targetIDArray    .begin() + oldResultSize
-	);
-	copy(
-			add_targetIndexArray.begin(),
-			add_targetIndexArray.end(),
-			targetIndexArray    .begin() + oldResultSize
-	);
-	copy(
-			add_queryIDArray.begin(),
-			add_queryIDArray.end(),
-			queryIDArray    .begin() + oldResultSize
-	);
-	copy(
-			add_queryIndexArray.begin(),
-			add_queryIndexArray.end(),
-			queryIndexArray    .begin() + oldResultSize
-	);
-	copy(
-			add_tHitLengthArray.begin(),
-			add_tHitLengthArray.end(),
-			tHitLengthArray    .begin() + oldResultSize
-	);
-	copy(
-			add_qHitLengthArray.begin(),
-			add_qHitLengthArray.end(),
-			qHitLengthArray    .begin() + oldResultSize
-	);
-	copy(
-			add_matchNumArray.begin(),
-			add_matchNumArray.end(),
-			matchNumArray    .begin() + oldResultSize
-	);
-	copy(
-			add_scoreArray.begin(),
-			add_scoreArray.end(),
-			scoreArray    .begin() + oldResultSize
-	);
-	copy(
-			add_evalueArray.begin(),
-			add_evalueArray.end(),
-			evalueArray    .begin() + oldResultSize
-	);
-        #ifdef TIME_ATTACK
-                std::cout << "..............................finished.";
-                cudaEventRecord( stop, 0 );
-                cudaEventSynchronize( stop );
-                cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-                std::cout
-                                << " (costs " << elapsed_time_ms << "ms) "
-                                << add_targetIDArray.size() << " un-exact hits found."
-                                << std::endl;
-        #endif /* TIME_ATTACK */
+	time_attack::runLabeledWithSuffix(
+			"  ...writing un-exact matches", "..............................finished.",
+			[&] {
+				appendUnExactMatchResults(
+						add_targetIDArray,
+						add_targetIndexArray,
+						add_queryIDArray,
+						add_queryIndexArray,
+						add_tHitLengthArray,
+						add_qHitLengthArray,
+						add_matchNumArray,
+						add_scoreArray,
+						add_evalueArray,
+						targetIDArray,
+						targetIndexArray,
+						queryIDArray,
+						queryIndexArray,
+						tHitLengthArray,
+						qHitLengthArray,
+						matchNumArray,
+						scoreArray,
+						evalueArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << add_targetIDArray.size() << " un-exact hits found." << std::endl;
+			});
 }
 
 /************************************* class functions **************************************/
@@ -303,37 +337,26 @@ CDeviceHitList::CDeviceHitList(
 	/* prepare calculation of E-value */
 	thrust::device_vector<double> seed_evalueArray(seed_targetIDArray.size());
 
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...calculating E-value";
-	#endif /* TIME_ATTACK */
-	const int blockDim_x = 256;
-	const int seedAlignmentNum = seed_targetIDArray.size();
-	calculateEvalue<<<(seedAlignmentNum/blockDim_x)+1, blockDim_x>>>(
-			q_begin,
-			seedAlignmentNum,
-			s.getTotalDatabaseSize(),
-			s.getK(),
-			s.getLambda(),
-			raw_pointer_cast( &*q.getLengthArray().begin() ),
-			raw_pointer_cast( &*seed_queryIDArray .begin() ),
-			raw_pointer_cast( &*seed_scoreArray   .begin() ),
-			raw_pointer_cast( &*seed_evalueArray  .begin() )
-	);
-	#ifdef TIME_ATTACK
-		std::cout << "...................................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout
-				<< " (costs " << elapsed_time_ms << "ms) "
-				<< seed_targetIDArray.size() << " hits found."
-				<< std::endl;
-	#endif /* TIME ATTACK */
+	time_attack::runLabeledWithSuffix(
+			"  ...calculating E-value", "...................................finished.",
+			[&] {
+				const int blockDim_x = 256;
+				const int seedAlignmentNum = seed_targetIDArray.size();
+				calculateEvalue<<<(seedAlignmentNum/blockDim_x)+1, blockDim_x>>>(
+						q_begin,
+						seedAlignmentNum,
+						s.getTotalDatabaseSize(),
+						s.getK(),
+						s.getLambda(),
+						raw_pointer_cast( &*q.getLengthArray().begin() ),
+						raw_pointer_cast( &*seed_queryIDArray .begin() ),
+						raw_pointer_cast( &*seed_scoreArray   .begin() ),
+						raw_pointer_cast( &*seed_evalueArray  .begin() )
+				);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << seed_targetIDArray.size() << " hits found." << std::endl;
+			});
 
 	if(s.getCutOff() != -1) {
 		deleteHits_lowEValue(
@@ -383,32 +406,23 @@ CDeviceHitList::CDeviceHitList(
 				evalueArray);
 	}
 
-	#ifdef TIME_ATTACK
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...sorting results";
-	#endif /* TIME_ATTACK */
-	resultSorting(
-			targetIDArray,
-			targetIndexArray,
-			queryIDArray,
-			queryIndexArray,
-			tHitLengthArray,
-			qHitLengthArray,
-			matchNumArray,
-			scoreArray,
-			evalueArray);
-	#ifdef TIME_ATTACK
-		std::cout << ".......................................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout
-				<< " (costs " << elapsed_time_ms << "ms) "
-				<< targetIDArray.size() << " total hits found."
-				<< std::endl;
-	#endif /* TIME_ATTACK */
+	time_attack::runLabeledWithSuffix(
+			"  ...sorting results", ".......................................finished.",
+			[&] {
+				resultSorting(
+						targetIDArray,
+						targetIndexArray,
+						queryIDArray,
+						queryIndexArray,
+						tHitLengthArray,
+						qHitLengthArray,
+						matchNumArray,
+						scoreArray,
+						evalueArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << targetIDArray.size() << " total hits found." << std::endl;
+			});
 
 	deleteHits_duplicateResult(
 			targetIDArray,
@@ -423,29 +437,18 @@ CDeviceHitList::CDeviceHitList(
 }
 
 void CDeviceHitList::getResult(CHostResultHolder& holder) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...Record result to host";
-	#endif /* TIME_ATTACK */
-	holder.addResult(
-			targetIDArray,
-			targetIndexArray,
-			queryIDArray,
-			queryIndexArray,
-			tHitLengthArray,
-			qHitLengthArray,
-			matchNumArray,
-			scoreArray,
-			evalueArray);
-	#ifdef TIME_ATTACK
-		std::cout << ".................................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout << " (costs " << elapsed_time_ms << "ms)" << std::endl;
-	#endif /* TIME_ATTACK */
+	time_attack::runLabeled(
+			"  ...Record result to host", ".................................finished.",
+			[&] {
+				holder.addResult(
+						targetIDArray,
+						targetIndexArray,
+						queryIDArray,
+						queryIndexArray,
+						tHitLengthArray,
+						qHitLengthArray,
+						matchNumArray,
+						scoreArray,
+						evalueArray);
+			});
 }

--- a/src/device/CDeviceHitList_alignmentHits.cu
+++ b/src/device/CDeviceHitList_alignmentHits.cu
@@ -1,6 +1,8 @@
 #include "device/CDeviceHitList_alignmentHits.cuh"
 
 #include "util/common.hpp"
+#include "util/time_attack.hpp"
+#include <iostream>
 #include "kernel/krnlAlignment.cuh"
 #include "test_support/CTest.cuh"
 
@@ -117,6 +119,306 @@ void sortBeforeAlignForward(
 	);
 }
 
+void localAlignmentKernels(
+		const int q_begin,
+		const int t_begin,
+		const int hitNum,
+		const int allowableGap,
+		const CDeviceHashTable& h,
+		const CDeviceSeqList_query& q,
+		const dim3& initTempNodeBlock,
+		const dim3& alignNodeBlock,
+		const int initBlockDim_x,
+		const int alignBlockDim_x,
+		thrust::device_vector<int>& targetIDArray,
+		thrust::device_vector<int>& targetIndexArray,
+		thrust::device_vector<int>& queryIDArray,
+		thrust::device_vector<int>& queryIndexArray,
+		thrust::device_vector<int>& tHitLengthArray,
+		thrust::device_vector<int>& qHitLengthArray,
+		thrust::device_vector<int>& matchNumArray,
+		thrust::device_vector<int>& scoreArray,
+		thrust::device_vector<int>& tempNodeArray_score,
+		thrust::device_vector<int>& tempNodeArray_vertical,
+		thrust::device_vector<int>& tempNodeArray_horizontal,
+		thrust::device_vector<int>& tempNodeArray_matchNum) {
+	using namespace thrust;
+	sortBeforeAlignBackWard(
+			q_begin,
+			q.getLengthArray(),
+			targetIDArray,
+			queryIDArray,
+			targetIndexArray,
+			queryIndexArray,
+			tHitLengthArray,
+			qHitLengthArray,
+			matchNumArray,
+			scoreArray);
+	initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+	localAlignBackward<<<alignNodeBlock, alignBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			t_begin,
+			q_begin,
+			raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
+			raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
+			raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
+			raw_pointer_cast( &*q.getGateway()    .begin() ),
+			raw_pointer_cast( &*q.getLengthArray().begin() ),
+			raw_pointer_cast( &*q.getBaseArray()  .begin() ),
+			raw_pointer_cast( &*targetIDArray   .begin() ),
+			raw_pointer_cast( &*queryIDArray    .begin() ),
+			raw_pointer_cast( &*targetIndexArray.begin() ),
+			raw_pointer_cast( &*queryIndexArray .begin() ),
+			raw_pointer_cast( &*tHitLengthArray .begin() ),
+			raw_pointer_cast( &*qHitLengthArray .begin() ),
+			raw_pointer_cast( &*matchNumArray   .begin() ),
+			raw_pointer_cast( &*scoreArray      .begin() ),
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+	sortBeforeAlignForward(
+			targetIDArray,
+			queryIDArray,
+			targetIndexArray,
+			queryIndexArray,
+			tHitLengthArray,
+			qHitLengthArray,
+			matchNumArray,
+			scoreArray);
+	initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+	localAlignForward<<<alignNodeBlock, alignBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			t_begin,
+			q_begin,
+			raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
+			raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
+			raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
+			raw_pointer_cast( &*q.getGateway()    .begin() ),
+			raw_pointer_cast( &*q.getLengthArray().begin() ),
+			raw_pointer_cast( &*q.getBaseArray()  .begin() ),
+			raw_pointer_cast( &*targetIDArray   .begin() ),
+			raw_pointer_cast( &*queryIDArray    .begin() ),
+			raw_pointer_cast( &*targetIndexArray.begin() ),
+			raw_pointer_cast( &*queryIndexArray .begin() ),
+			raw_pointer_cast( &*tHitLengthArray .begin() ),
+			raw_pointer_cast( &*qHitLengthArray .begin() ),
+			raw_pointer_cast( &*matchNumArray   .begin() ),
+			raw_pointer_cast( &*scoreArray      .begin() ),
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+}
+
+void globalAlignmentKernels(
+		const int q_begin,
+		const int t_begin,
+		const int hitNum,
+		const int allowableGap,
+		const CDeviceHashTable& h,
+		const CDeviceSeqList_query& q,
+		const dim3& initTempNodeBlock,
+		const dim3& alignNodeBlock,
+		const int initBlockDim_x,
+		const int alignBlockDim_x,
+		thrust::device_vector<int>& targetIDArray,
+		thrust::device_vector<int>& targetIndexArray,
+		thrust::device_vector<int>& queryIDArray,
+		thrust::device_vector<int>& queryIndexArray,
+		thrust::device_vector<int>& tHitLengthArray,
+		thrust::device_vector<int>& qHitLengthArray,
+		thrust::device_vector<int>& matchNumArray,
+		thrust::device_vector<int>& scoreArray,
+		thrust::device_vector<int>& tempNodeArray_score,
+		thrust::device_vector<int>& tempNodeArray_vertical,
+		thrust::device_vector<int>& tempNodeArray_horizontal,
+		thrust::device_vector<int>& tempNodeArray_matchNum) {
+	using namespace thrust;
+	sortBeforeAlignBackWard(
+			q_begin,
+			q.getLengthArray(),
+			targetIDArray,
+			queryIDArray,
+			targetIndexArray,
+			queryIndexArray,
+			tHitLengthArray,
+			qHitLengthArray,
+			matchNumArray,
+			scoreArray);
+	initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+	globalAlignBackward<<<alignNodeBlock, alignBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			t_begin,
+			q_begin,
+			raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
+			raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
+			raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
+			raw_pointer_cast( &*q.getGateway()    .begin() ),
+			raw_pointer_cast( &*q.getLengthArray().begin() ),
+			raw_pointer_cast( &*q.getBaseArray()  .begin() ),
+			raw_pointer_cast( &*targetIDArray   .begin() ),
+			raw_pointer_cast( &*queryIDArray    .begin() ),
+			raw_pointer_cast( &*targetIndexArray.begin() ),
+			raw_pointer_cast( &*queryIndexArray .begin() ),
+			raw_pointer_cast( &*tHitLengthArray .begin() ),
+			raw_pointer_cast( &*qHitLengthArray .begin() ),
+			raw_pointer_cast( &*matchNumArray   .begin() ),
+			raw_pointer_cast( &*scoreArray      .begin() ),
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+	sortBeforeAlignForward(
+			targetIDArray,
+			queryIDArray,
+			targetIndexArray,
+			queryIndexArray,
+			tHitLengthArray,
+			qHitLengthArray,
+			matchNumArray,
+			scoreArray);
+	initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+	globalAlignForward<<<alignNodeBlock, alignBlockDim_x>>>(
+			hitNum,
+			allowableGap,
+			t_begin,
+			q_begin,
+			raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
+			raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
+			raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
+			raw_pointer_cast( &*q.getGateway()    .begin() ),
+			raw_pointer_cast( &*q.getLengthArray().begin() ),
+			raw_pointer_cast( &*q.getBaseArray()  .begin() ),
+			raw_pointer_cast( &*targetIDArray   .begin() ),
+			raw_pointer_cast( &*queryIDArray    .begin() ),
+			raw_pointer_cast( &*targetIndexArray.begin() ),
+			raw_pointer_cast( &*queryIndexArray .begin() ),
+			raw_pointer_cast( &*tHitLengthArray .begin() ),
+			raw_pointer_cast( &*qHitLengthArray .begin() ),
+			raw_pointer_cast( &*matchNumArray   .begin() ),
+			raw_pointer_cast( &*scoreArray      .begin() ),
+			raw_pointer_cast( &*tempNodeArray_score     .begin() ),
+			raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
+			raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
+			raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
+	);
+}
+
+void runAlignmentSeedsKernels(
+		const CHostSetting& s,
+		const CDeviceHashTable& h,
+		const CDeviceSeqList_query& q,
+		const int t_begin,
+		const int q_begin,
+		thrust::device_vector<int>& targetIDArray,
+		thrust::device_vector<int>& targetIndexArray,
+		thrust::device_vector<int>& queryIDArray,
+		thrust::device_vector<int>& queryIndexArray,
+		thrust::device_vector<int>& tHitLengthArray,
+		thrust::device_vector<int>& qHitLengthArray,
+		thrust::device_vector<int>& matchNumArray,
+		thrust::device_vector<int>& scoreArray) {
+	using namespace thrust;
+	const int initBlockDim_x = 256;
+	const int alignBlockDim_x = 32;
+	const int hitNum = static_cast<int>(targetIDArray.size());
+	const int allowableGap = s.getAllowableGap();
+	const int tempNodeWidth = 1 + 2 * (allowableGap + MARGIN);
+	const int tempNodeArraySize = hitNum * tempNodeWidth;
+	device_vector<int> tempNodeArray_score(tempNodeArraySize);
+	device_vector<int> tempNodeArray_vertical(tempNodeArraySize);
+	device_vector<int> tempNodeArray_horizontal(tempNodeArraySize);
+	device_vector<int> tempNodeArray_matchNum(tempNodeArraySize);
+	const int initBlockNum = (tempNodeArraySize / initBlockDim_x) + 1;
+	const dim3 initTempNodeBlock(65535, (initBlockNum / 65535) + 1, 1);
+	const int alignBlockNum = (hitNum / alignBlockDim_x) + 1;
+	const dim3 alignNodeBlock(65535, (alignBlockNum / 65535) + 1, 1);
+	if (s.getFlgLocal()) {
+		localAlignmentKernels(
+				q_begin,
+				t_begin,
+				hitNum,
+				allowableGap,
+				h,
+				q,
+				initTempNodeBlock,
+				alignNodeBlock,
+				initBlockDim_x,
+				alignBlockDim_x,
+				targetIDArray,
+				targetIndexArray,
+				queryIDArray,
+				queryIndexArray,
+				tHitLengthArray,
+				qHitLengthArray,
+				matchNumArray,
+				scoreArray,
+				tempNodeArray_score,
+				tempNodeArray_vertical,
+				tempNodeArray_horizontal,
+				tempNodeArray_matchNum);
+	} else {
+		globalAlignmentKernels(
+				q_begin,
+				t_begin,
+				hitNum,
+				allowableGap,
+				h,
+				q,
+				initTempNodeBlock,
+				alignNodeBlock,
+				initBlockDim_x,
+				alignBlockDim_x,
+				targetIDArray,
+				targetIndexArray,
+				queryIDArray,
+				queryIndexArray,
+				tHitLengthArray,
+				qHitLengthArray,
+				matchNumArray,
+				scoreArray,
+				tempNodeArray_score,
+				tempNodeArray_vertical,
+				tempNodeArray_horizontal,
+				tempNodeArray_matchNum);
+	}
+}
+
 /******************************** public ************************************/
 
 void alignmentHits(
@@ -133,210 +435,29 @@ void alignmentHits(
 		thrust::device_vector<int>& qHitLengthArray,
 		thrust::device_vector<int>& matchNumArray,
 		thrust::device_vector<int>& scoreArray) {
-        using namespace thrust;
-        #ifdef TIME_ATTACK
-                float elapsed_time_ms=0.0f;
-                cudaEvent_t start, stop;
-                cudaEventCreate( &start );
-                cudaEventCreate( &stop  );
-                cudaEventRecord( start, 0 );
-                std::cout << "  ...allignment seeds";
-        #endif /* TIME_ATTACK */
-        const int initBlockDim_x  = 256;
-	const int alignBlockDim_x = 32;
-	const int hitNum = targetIDArray.size();
-        const int allowableGap = s.getAllowableGap();
-        const int tempNodeWidth = 1 + 2 * (allowableGap + MARGIN);
-        const int tempNodeArraySize = hitNum * tempNodeWidth;
-        device_vector<int> tempNodeArray_score     (tempNodeArraySize);
-        device_vector<int> tempNodeArray_vertical  (tempNodeArraySize);
-        device_vector<int> tempNodeArray_horizontal(tempNodeArraySize);
-        device_vector<int> tempNodeArray_matchNum  (tempNodeArraySize);
-        const int  initBlockNum = (tempNodeArraySize / initBlockDim_x) + 1;
-        const dim3 initTempNodeBlock(65535, (initBlockNum/65535)+1, 1);
-        const int  alignBlockNum = (hitNum/alignBlockDim_x)+1;
-        const dim3 alignNodeBlock(65535, (alignBlockNum/65535)+1, 1);
-	if(s.getFlgLocal()) {
-		sortBeforeAlignBackWard(
-				q_begin,
-				q.getLengthArray(),
-				targetIDArray,
-				queryIDArray,
-				targetIndexArray,
-				queryIndexArray,
-				tHitLengthArray,
-				qHitLengthArray,
-				matchNumArray,
-				scoreArray);
-		initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
-				hitNum,
-				allowableGap,
-				raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-				raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-				raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-				raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-		);
-		localAlignBackward<<<alignNodeBlock, alignBlockDim_x>>>(
-				hitNum,
-				allowableGap,
-				t_begin,
-				q_begin,
-				raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
-				raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
-				raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
-				raw_pointer_cast( &*q.getGateway()    .begin() ),
-				raw_pointer_cast( &*q.getLengthArray().begin() ),
-				raw_pointer_cast( &*q.getBaseArray()  .begin() ),
-				raw_pointer_cast( &*targetIDArray   .begin() ),
-				raw_pointer_cast( &*queryIDArray    .begin() ),
-				raw_pointer_cast( &*targetIndexArray.begin() ),
-				raw_pointer_cast( &*queryIndexArray .begin() ),
-				raw_pointer_cast( &*tHitLengthArray .begin() ),
-				raw_pointer_cast( &*qHitLengthArray .begin() ),
-				raw_pointer_cast( &*matchNumArray   .begin() ),
-				raw_pointer_cast( &*scoreArray      .begin() ),
-				raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-				raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-				raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-				raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-		);
-		sortBeforeAlignForward(
-				targetIDArray,
-				queryIDArray,
-				targetIndexArray,
-				queryIndexArray,
-				tHitLengthArray,
-				qHitLengthArray,
-				matchNumArray,
-				scoreArray);
-                initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
-                                hitNum,
-                                allowableGap,
-                                raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-                                raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-                                raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-                                raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-                );
-		localAlignForward<<<alignNodeBlock, alignBlockDim_x>>>(
-				hitNum,
-				allowableGap,
-				t_begin,
-				q_begin,
-				raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
-				raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
-				raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
-				raw_pointer_cast( &*q.getGateway()    .begin() ),
-				raw_pointer_cast( &*q.getLengthArray().begin() ),
-				raw_pointer_cast( &*q.getBaseArray()  .begin() ),
-				raw_pointer_cast( &*targetIDArray   .begin() ),
-				raw_pointer_cast( &*queryIDArray    .begin() ),
-				raw_pointer_cast( &*targetIndexArray.begin() ),
-				raw_pointer_cast( &*queryIndexArray .begin() ),
-				raw_pointer_cast( &*tHitLengthArray .begin() ),
-				raw_pointer_cast( &*qHitLengthArray .begin() ),
-				raw_pointer_cast( &*matchNumArray   .begin() ),
-				raw_pointer_cast( &*scoreArray      .begin() ),
-				raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-				raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-				raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-				raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-		);
-	} else {
-		sortBeforeAlignBackWard(
-				q_begin,
-				q.getLengthArray(),
-				targetIDArray,
-				queryIDArray,
-				targetIndexArray,
-				queryIndexArray,
-				tHitLengthArray,
-				qHitLengthArray,
-				matchNumArray,
-				scoreArray);
-		initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
-				hitNum,
-				allowableGap,
-				raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-				raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-				raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-				raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-		);
-		globalAlignBackward<<<alignNodeBlock, alignBlockDim_x>>>(
-				hitNum,
-				allowableGap,
-				t_begin,
-				q_begin,
-				raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
-				raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
-				raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
-				raw_pointer_cast( &*q.getGateway()    .begin() ),
-				raw_pointer_cast( &*q.getLengthArray().begin() ),
-				raw_pointer_cast( &*q.getBaseArray()  .begin() ),
-				raw_pointer_cast( &*targetIDArray   .begin() ),
-				raw_pointer_cast( &*queryIDArray    .begin() ),
-				raw_pointer_cast( &*targetIndexArray.begin() ),
-				raw_pointer_cast( &*queryIndexArray .begin() ),
-				raw_pointer_cast( &*tHitLengthArray .begin() ),
-				raw_pointer_cast( &*qHitLengthArray .begin() ),
-				raw_pointer_cast( &*matchNumArray   .begin() ),
-				raw_pointer_cast( &*scoreArray      .begin() ),
-				raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-				raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-				raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-				raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-		);
-		sortBeforeAlignForward(
-				targetIDArray,
-				queryIDArray,
-				targetIndexArray,
-				queryIndexArray,
-				tHitLengthArray,
-				qHitLengthArray,
-				matchNumArray,
-				scoreArray);
-		initTempNodeArray<<<initTempNodeBlock, initBlockDim_x>>>(
-				hitNum,
-				allowableGap,
-				raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-				raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-				raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-				raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-		);
-		globalAlignForward<<<alignNodeBlock, alignBlockDim_x>>>(
-				hitNum,
-				allowableGap,
-				t_begin,
-				q_begin,
-				raw_pointer_cast( &*h.getTarget().getGateway()    .begin() ),
-				raw_pointer_cast( &*h.getTarget().getLengthArray().begin() ),
-				raw_pointer_cast( &*h.getTarget().getBaseArray()  .begin() ),
-				raw_pointer_cast( &*q.getGateway()    .begin() ),
-				raw_pointer_cast( &*q.getLengthArray().begin() ),
-				raw_pointer_cast( &*q.getBaseArray()  .begin() ),
-				raw_pointer_cast( &*targetIDArray   .begin() ),
-				raw_pointer_cast( &*queryIDArray    .begin() ),
-				raw_pointer_cast( &*targetIndexArray.begin() ),
-				raw_pointer_cast( &*queryIndexArray .begin() ),
-				raw_pointer_cast( &*tHitLengthArray .begin() ),
-				raw_pointer_cast( &*qHitLengthArray .begin() ),
-				raw_pointer_cast( &*matchNumArray   .begin() ),
-				raw_pointer_cast( &*scoreArray      .begin() ),
-				raw_pointer_cast( &*tempNodeArray_score     .begin() ),
-				raw_pointer_cast( &*tempNodeArray_vertical  .begin() ),
-				raw_pointer_cast( &*tempNodeArray_horizontal.begin() ),
-				raw_pointer_cast( &*tempNodeArray_matchNum  .begin() )
-		);
-	}
-        #ifdef TIME_ATTACK
-                std::cout << "......................................finished.";
-                cudaEventRecord( stop, 0 );
-                cudaEventSynchronize( stop );
-                cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-                std::cout
-                                << " (costs " << elapsed_time_ms << "ms) "
-                                << targetIDArray.size() << " hits found."
-                                << std::endl;
-        #endif /* TIME_ATTACK */
+	using namespace thrust;
+	time_attack::runLabeledWithSuffix(
+			"  ...allignment seeds",
+			"......................................finished.",
+			[&] {
+				runAlignmentSeedsKernels(
+						s,
+						h,
+						q,
+						t_begin,
+						q_begin,
+						targetIDArray,
+						targetIndexArray,
+						queryIDArray,
+						queryIndexArray,
+						tHitLengthArray,
+						qHitLengthArray,
+						matchNumArray,
+						scoreArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << targetIDArray.size() << " hits found." << std::endl;
+			});
 	#ifdef MODE_TEST
 		CTest::printIsolatedHit(
 				targetIDArray,

--- a/src/device/CDeviceHitList_createRawSeedList.cu
+++ b/src/device/CDeviceHitList_createRawSeedList.cu
@@ -4,10 +4,8 @@
 #include "kernel/krnlWriteSeedList.cuh"
 
 #include "util/common.hpp"
-
-#ifdef TIME_ATTACK
-	#include <iostream>
-#endif /* TIME_ATTACK */
+#include "util/time_attack.hpp"
+#include <iostream>
 
 #ifdef MODE_TEST
 	#include "test_support/CTest.cuh"
@@ -134,6 +132,66 @@ void writeCellSizeArray(
 	}
 }
 
+void buildRawSeedList(
+		const CDeviceHashTable& h,
+		const CDeviceSeqList_query& q,
+		thrust::device_vector<int>& seed_targetIDArray,
+		thrust::device_vector<int>& seed_targetIndexArray,
+		thrust::device_vector<int>& seed_queryIDArray,
+		thrust::device_vector<int>& seed_queryIndexArray) {
+	using namespace thrust;
+
+	const device_vector<long>& qHashIndexArray = q.getHashIndex();
+
+	device_vector<int> gatewayKeyArray(qHashIndexArray.size());
+	writeGatewayKey(
+			h.getGatewayKey(),
+			qHashIndexArray,
+			gatewayKeyArray);
+
+	device_vector<int> gatewayIndexArray(qHashIndexArray.size());
+	writeGatewayIndexArray(
+			h.getGatewayIndex(),
+			gatewayKeyArray,
+			gatewayIndexArray);
+
+	device_vector<int> cellSizeArray(qHashIndexArray.size());
+	writeCellSizeArray(
+			h.getCellSizeArray(),
+			gatewayKeyArray,
+			cellSizeArray);
+
+	device_vector<int> seedWriteIndexArray(qHashIndexArray.size());
+	exclusive_scan(cellSizeArray.begin(), cellSizeArray.end(), seedWriteIndexArray.begin());
+
+	const int seedNum = seedWriteIndexArray.back() + cellSizeArray.back();
+	seed_targetIDArray.resize(seedNum);
+	seed_targetIndexArray.resize(seedNum);
+	seed_queryIDArray.resize(seedNum);
+	seed_queryIndexArray.resize(seedNum);
+
+	/* write seed list */ {
+		const int blockDim_x = 256;
+		const int blockNum = (qHashIndexArray.size() / blockDim_x) + 1;
+		const dim3 block(65535, (blockNum - 1) / 65535 + 1, 1);
+		writeSeedList<<<block, blockDim_x>>>(
+				qHashIndexArray.size(),
+				raw_pointer_cast( &*gatewayIndexArray.begin() ),
+				raw_pointer_cast( &*h.getIndexArray().begin() ),
+				raw_pointer_cast( &*seedWriteIndexArray.begin() ),
+				raw_pointer_cast( &*cellSizeArray.begin() ),
+				raw_pointer_cast( &*h.getTarget().getIDArray().begin() ),
+				raw_pointer_cast( &*h.getTarget().getIndexArray().begin() ),
+				raw_pointer_cast( &*q.getIDArray().begin() ),
+				raw_pointer_cast( &*q.getIndexArray().begin() ),
+				raw_pointer_cast( &*seed_targetIDArray.begin() ),
+				raw_pointer_cast( &*seed_targetIndexArray.begin() ),
+				raw_pointer_cast( &*seed_queryIDArray.begin() ),
+				raw_pointer_cast( &*seed_queryIndexArray.begin() )
+		);
+	}
+}
+
 /********************************** public **********************************/
 
 void createRawSeedList(
@@ -147,76 +205,21 @@ void createRawSeedList(
 		thrust::device_vector<int>& seed_queryIDArray,
 		thrust::device_vector<int>& seed_queryIndexArray) {
 	try {
-		#ifdef TIME_ATTACK
-			float elapsed_time_ms=0.0f;
-			cudaEvent_t start, stop;
-			cudaEventCreate( &start );
-			cudaEventCreate( &stop  );
-			cudaEventRecord( start, 0 );
-			std::cout << std::endl << "  ...creating raw seed list";
-		#endif /* TIME_ATTACK */
-		using namespace thrust;
-
-		const device_vector<long>& qHashIndexArray = q.getHashIndex();
-
-		device_vector<int> gatewayKeyArray(qHashIndexArray.size());
-		writeGatewayKey(
-				h.getGatewayKey(),
-				qHashIndexArray,
-				gatewayKeyArray);
-
-		device_vector<int> gatewayIndexArray(qHashIndexArray.size());
-		writeGatewayIndexArray(
-				h.getGatewayIndex(),
-				gatewayKeyArray,
-				gatewayIndexArray);
-
-		device_vector<int> cellSizeArray(qHashIndexArray.size());
-		writeCellSizeArray(
-				h.getCellSizeArray(),
-				gatewayKeyArray,
-				cellSizeArray);
-
-		device_vector<int> seedWriteIndexArray(qHashIndexArray.size());
-		exclusive_scan(cellSizeArray.begin(), cellSizeArray.end(), seedWriteIndexArray.begin());
-
-		const int seedNum = seedWriteIndexArray.back() + cellSizeArray.back();
-		seed_targetIDArray   .resize(seedNum);
-		seed_targetIndexArray.resize(seedNum);
-		seed_queryIDArray    .resize(seedNum);
-		seed_queryIndexArray .resize(seedNum);
-
-		/* wtire seed list */ {
-			const int blockDim_x = 256;
-			const int blockNum = (qHashIndexArray.size() / blockDim_x) + 1;
-			const dim3 block(65535, (blockNum - 1) / 65535 + 1, 1);
-			writeSeedList<<<block, blockDim_x>>>(
-					qHashIndexArray.size(),
-					raw_pointer_cast( &*gatewayIndexArray  .begin() ),
-					raw_pointer_cast( &*h.getIndexArray()  .begin() ),
-					raw_pointer_cast( &*seedWriteIndexArray.begin() ),
-					raw_pointer_cast( &*cellSizeArray      .begin() ),
-					raw_pointer_cast( &*h.getTarget().getIDArray()   .begin() ),
-					raw_pointer_cast( &*h.getTarget().getIndexArray().begin() ),
-					raw_pointer_cast( &*q.getIDArray()   .begin() ),
-					raw_pointer_cast( &*q.getIndexArray().begin() ),
-					raw_pointer_cast( &*seed_targetIDArray   .begin() ),
-					raw_pointer_cast( &*seed_targetIndexArray.begin() ),
-					raw_pointer_cast( &*seed_queryIDArray    .begin() ),
-					raw_pointer_cast( &*seed_queryIndexArray .begin() )
-			);
-		}
-
-		#ifdef TIME_ATTACK
-			std::cout << "................................finished.";
-			cudaEventRecord( stop, 0 );
-			cudaEventSynchronize( stop );
-			cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-			std::cout
-					<< " (costs " << elapsed_time_ms << "ms) "
-					<< seed_targetIDArray.size() << " hits found."
-					<< std::endl;
-		#endif /* TIME_ATTACK */
+		time_attack::runLabeledWithSuffix(
+				"\n  ...creating raw seed list",
+				"................................finished.",
+				[&] {
+					buildRawSeedList(
+							h,
+							q,
+							seed_targetIDArray,
+							seed_targetIndexArray,
+							seed_queryIDArray,
+							seed_queryIndexArray);
+				},
+				[&](std::ostream& os, float /*ms*/) {
+					os << seed_targetIDArray.size() << " hits found." << std::endl;
+				});
 		#ifdef MODE_TEST
 			CTest::printQueryToTarget(
 					seed_targetIDArray,

--- a/src/device/CDeviceHitList_deleteBadHits.cu
+++ b/src/device/CDeviceHitList_deleteBadHits.cu
@@ -1,11 +1,15 @@
 #include "device/CDeviceHitList_deleteBadHits.cuh"
 
+#include "util/common.hpp"
+#include "util/time_attack.hpp"
+
+#include <iostream>
 #include <thrust/host_vector.h>
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/remove.h>
 
-void deleteHits_lowEValue(
+void removeLowEValueHits(
 		const double cutOffEValue,
 		thrust::device_vector<int>& targetIDArray,
 		thrust::device_vector<int>& targetIndexArray,
@@ -16,14 +20,6 @@ void deleteHits_lowEValue(
 		thrust::device_vector<int>& matchNumArray,
 		thrust::device_vector<int>& scoreArray,
 		thrust::device_vector<double>& evalueArray) {
-        #ifdef TIME_ATTACK
-                float elapsed_time_ms=0.0f;
-                cudaEvent_t start, stop;
-                cudaEventCreate( &start );
-                cudaEventCreate( &stop  );
-                cudaEventRecord( start, 0 );
-                std::cout << "  ...deleting hits which has low e-value";
-        #endif /* TIME_ATTACK */
 	using namespace thrust;
 	host_vector<int>    h_targetIDArray    = targetIDArray;
 	host_vector<int>    h_targetIndexArray = targetIndexArray;
@@ -101,19 +97,40 @@ void deleteHits_lowEValue(
 	matchNumArray   .resize(new_size);
 	scoreArray      .resize(new_size);
 	evalueArray     .resize(new_size);
-        #ifdef TIME_ATTACK
-                std::cout << "...................finished.";
-                cudaEventRecord( stop, 0 );
-                cudaEventSynchronize( stop );
-                cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-                std::cout
-                                << " (costs " << elapsed_time_ms << "ms) "
-                                << seed_targetIDArray.size() << " un-exact hits found."
-                                << std::endl;
-        #endif /* TIME_ATTACK */
 }
 
-void deleteHits_tooShort(
+void deleteHits_lowEValue(
+		const double cutOffEValue,
+		thrust::device_vector<int>& targetIDArray,
+		thrust::device_vector<int>& targetIndexArray,
+		thrust::device_vector<int>& queryIDArray,
+		thrust::device_vector<int>& queryIndexArray,
+		thrust::device_vector<int>& tHitLengthArray,
+		thrust::device_vector<int>& qHitLengthArray,
+		thrust::device_vector<int>& matchNumArray,
+		thrust::device_vector<int>& scoreArray,
+		thrust::device_vector<double>& evalueArray) {
+	time_attack::runLabeledWithSuffix(
+			"  ...deleting hits which has low e-value", "...................finished.",
+			[&] {
+				removeLowEValueHits(
+						cutOffEValue,
+						targetIDArray,
+						targetIndexArray,
+						queryIDArray,
+						queryIndexArray,
+						tHitLengthArray,
+						qHitLengthArray,
+						matchNumArray,
+						scoreArray,
+						evalueArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << targetIDArray.size() << " un-exact hits found." << std::endl;
+			});
+}
+
+void removeTooShortHits(
 		const CHostSetting& s,
 		thrust::device_vector<int>& targetIDArray,
 		thrust::device_vector<int>& targetIndexArray,
@@ -124,14 +141,6 @@ void deleteHits_tooShort(
 		thrust::device_vector<int>& matchNumArray,
 		thrust::device_vector<int>& scoreArray,
 		thrust::device_vector<double>& evalueArray) {
-        #ifdef TIME_ATTACK
-                float elapsed_time_ms=0.0f;
-                cudaEvent_t start, stop;
-                cudaEventCreate( &start );
-                cudaEventCreate( &stop  );
-                cudaEventRecord( start, 0 );
-                std::cout << "  ...deleting too short hits";
-        #endif /* TIME_ATTACK */
 	using namespace thrust;
 	host_vector<int>    h_targetIDArray    = targetIDArray;
 	host_vector<int>    h_targetIndexArray = targetIndexArray;
@@ -209,14 +218,35 @@ void deleteHits_tooShort(
 	matchNumArray   .resize(new_size);
 	scoreArray      .resize(new_size);
 	evalueArray     .resize(new_size);
-        #ifdef TIME_ATTACK
-                std::cout << "...............................finished.";
-                cudaEventRecord( stop, 0 );
-                cudaEventSynchronize( stop );
-                cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-                std::cout
-                                << " (costs " << elapsed_time_ms << "ms) "
-                                << seed_targetIDArray.size() << " un-exact hits found."
-                                << std::endl;
-        #endif /* TIME_ATTACK */
+}
+
+void deleteHits_tooShort(
+		const CHostSetting& s,
+		thrust::device_vector<int>& targetIDArray,
+		thrust::device_vector<int>& targetIndexArray,
+		thrust::device_vector<int>& queryIDArray,
+		thrust::device_vector<int>& queryIndexArray,
+		thrust::device_vector<int>& tHitLengthArray,
+		thrust::device_vector<int>& qHitLengthArray,
+		thrust::device_vector<int>& matchNumArray,
+		thrust::device_vector<int>& scoreArray,
+		thrust::device_vector<double>& evalueArray) {
+	time_attack::runLabeledWithSuffix(
+			"  ...deleting too short hits", "...............................finished.",
+			[&] {
+				removeTooShortHits(
+						s,
+						targetIDArray,
+						targetIndexArray,
+						queryIDArray,
+						queryIndexArray,
+						tHitLengthArray,
+						qHitLengthArray,
+						matchNumArray,
+						scoreArray,
+						evalueArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << targetIDArray.size() << " un-exact hits found." << std::endl;
+			});
 }

--- a/src/device/CDeviceHitList_deleteDuplicateSeeds.cu
+++ b/src/device/CDeviceHitList_deleteDuplicateSeeds.cu
@@ -2,29 +2,20 @@
 #include "device/CDeviceHitList_seed_host_api.cuh"
 
 #include "util/common.hpp"
-#ifdef TIME_ATTACK
-	#include <iostream>
-#endif
+#include "util/time_attack.hpp"
+#include <iostream>
 #ifdef MODE_TEST
 	#include "test_support/CTest.cuh"
 #endif
 
 #include <thrust/host_vector.h>
 
-void deleteDuplicateSeeds(
+void removeDuplicateSeeds(
 		const CHostSetting& s,
 		thrust::device_vector<int>& seed_targetIDArray,
 		thrust::device_vector<int>& seed_targetIndexArray,
 		thrust::device_vector<int>& seed_queryIDArray,
 		thrust::device_vector<int>& seed_queryIndexArray) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...deleting duplicate seeds";
-	#endif /* TIME_ATTACK */
 	using namespace thrust;
 	host_vector<int> h_tIDArray  = seed_targetIDArray;
 	host_vector<int> h_tIdxArray = seed_targetIndexArray;
@@ -46,16 +37,27 @@ void deleteDuplicateSeeds(
 	seed_targetIndexArray.resize(newSize);
 	seed_queryIDArray    .resize(newSize);
 	seed_queryIndexArray .resize(newSize);
-	#ifdef TIME_ATTACK
-		std::cout << "..............................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout
-				<< " (costs " << elapsed_time_ms << "ms) "
-				<< seed_targetIDArray.size() << " hits found."
-				<< std::endl;
-	#endif /* TIME_ATTACK */
+}
+
+void deleteDuplicateSeeds(
+		const CHostSetting& s,
+		thrust::device_vector<int>& seed_targetIDArray,
+		thrust::device_vector<int>& seed_targetIndexArray,
+		thrust::device_vector<int>& seed_queryIDArray,
+		thrust::device_vector<int>& seed_queryIndexArray) {
+	time_attack::runLabeledWithSuffix(
+			"  ...deleting duplicate seeds", "..............................finished.",
+			[&] {
+				removeDuplicateSeeds(
+						s,
+						seed_targetIDArray,
+						seed_targetIndexArray,
+						seed_queryIDArray,
+						seed_queryIndexArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << seed_targetIDArray.size() << " hits found." << std::endl;
+			});
 	#ifdef MODE_TEST
 		CTest::printQueryToTarget(
 				seed_targetIDArray,

--- a/src/device/CDeviceHitList_deleteIsolateSeeds.cu
+++ b/src/device/CDeviceHitList_deleteIsolateSeeds.cu
@@ -2,10 +2,8 @@
 #include "device/CDeviceHitList_seed_host_api.cuh"
 
 #include "util/common.hpp"
-
-#ifdef TIME_ATTACK
-	#include <iostream>
-#endif
+#include "util/time_attack.hpp"
+#include <iostream>
 
 #ifdef MODE_TEST
 	#include "test_support/CTest.cuh"
@@ -13,23 +11,13 @@
 
 #include <thrust/host_vector.h>
 
-#include <thrust/functional.h>
-
-void deletingIsolateSeeds(
+void removeIsolateSeeds(
 		const int allowableWidth,
 		const int allowableGap,
 		thrust::device_vector<int>& seed_targetIDArray,
 		thrust::device_vector<int>& seed_targetIndexArray,
 		thrust::device_vector<int>& seed_queryIDArray,
 		thrust::device_vector<int>& seed_queryIndexArray) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...deleting isolate seeds";
-	#endif /* TIME_ATTACK */
 	using namespace thrust;
 	host_vector<int> h_tIDArray  = seed_targetIDArray;
 	host_vector<int> h_tIdxArray = seed_targetIndexArray;
@@ -51,16 +39,29 @@ void deletingIsolateSeeds(
 	seed_targetIndexArray.resize(newSize);
 	seed_queryIDArray    .resize(newSize);
 	seed_queryIndexArray .resize(newSize);
-	#ifdef TIME_ATTACK
-		std::cout << "................................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout
-				<< " (costs " << elapsed_time_ms << "ms) "
-				<< seed_targetIDArray.size() << " hits found."
-				<< std::endl;
-	#endif /* TIME_ATTACK */
+}
+
+void deletingIsolateSeeds(
+		const int allowableWidth,
+		const int allowableGap,
+		thrust::device_vector<int>& seed_targetIDArray,
+		thrust::device_vector<int>& seed_targetIndexArray,
+		thrust::device_vector<int>& seed_queryIDArray,
+		thrust::device_vector<int>& seed_queryIndexArray) {
+	time_attack::runLabeledWithSuffix(
+			"  ...deleting isolate seeds", "................................finished.",
+			[&] {
+				removeIsolateSeeds(
+						allowableWidth,
+						allowableGap,
+						seed_targetIDArray,
+						seed_targetIndexArray,
+						seed_queryIDArray,
+						seed_queryIndexArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << seed_targetIDArray.size() << " hits found." << std::endl;
+			});
 	#ifdef MODE_TEST
 		CTest::printQueryToTarget(
 				seed_targetIDArray,

--- a/src/device/CDeviceHitList_deleteSeedsOnSequenceBoundary.cu
+++ b/src/device/CDeviceHitList_deleteSeedsOnSequenceBoundary.cu
@@ -2,10 +2,8 @@
 #include "device/CDeviceHitList_seed_host_api.cuh"
 
 #include "util/common.hpp"
-
-#ifdef TIME_ATTACK
-	#include <iostream>
-#endif
+#include "util/time_attack.hpp"
+#include <iostream>
 
 #ifdef MODE_TEST
 	#include "test_support/CTest.cuh"
@@ -13,7 +11,7 @@
 
 #include <thrust/host_vector.h>
 
-void deleteSeedsOnSequenceBoundary(
+void removeSeedsOnSequenceBoundary(
 		const CHostSetting& s,
 		const CDeviceHashTable& h,
 		const CDeviceSeqList_query& q,
@@ -23,14 +21,6 @@ void deleteSeedsOnSequenceBoundary(
 		thrust::device_vector<int>& seed_targetIndexArray,
 		thrust::device_vector<int>& seed_queryIDArray,
 		thrust::device_vector<int>& seed_queryIndexArray) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...deleting hits on sequence boundary";
-	#endif /* TIME_ATTACK */
 	using namespace thrust;
 	host_vector<int> h_tIDArray  = seed_targetIDArray;
 	host_vector<int> h_tIdxArray = seed_targetIndexArray;
@@ -52,17 +42,17 @@ void deleteSeedsOnSequenceBoundary(
 			h_tIdxArray,
 			h_qIDArray,
 			h_qIdxArray);
-	if(!s.getFlgLocal()) {
+	if (!s.getFlgLocal()) {
 		onCorner(
-			s.getAllowableGap(),
-			t_begin,
-			q_begin,
-			h.getTarget().getLengthArray(),
-			q.getLengthArray(),
-			h_tIDArray,
-			h_tIdxArray,
-			h_qIDArray,
-			h_qIdxArray);
+				s.getAllowableGap(),
+				t_begin,
+				q_begin,
+				h.getTarget().getLengthArray(),
+				q.getLengthArray(),
+				h_tIDArray,
+				h_tIdxArray,
+				h_qIDArray,
+				h_qIdxArray);
 	}
 	seed_targetIDArray    = h_tIDArray;
 	seed_targetIndexArray = h_tIdxArray;
@@ -73,16 +63,35 @@ void deleteSeedsOnSequenceBoundary(
 	seed_targetIndexArray.resize(newSize);
 	seed_queryIDArray    .resize(newSize);
 	seed_queryIndexArray .resize(newSize);
-	#ifdef TIME_ATTACK
-		std::cout << "....................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout
-				<< " (costs " << elapsed_time_ms << "ms) "
-				<< seed_targetIDArray.size() << " hits found."
-				<< std::endl;
-	#endif /* TIME_ATTACK */
+}
+
+void deleteSeedsOnSequenceBoundary(
+		const CHostSetting& s,
+		const CDeviceHashTable& h,
+		const CDeviceSeqList_query& q,
+		const int t_begin,
+		const int q_begin,
+		thrust::device_vector<int>& seed_targetIDArray,
+		thrust::device_vector<int>& seed_targetIndexArray,
+		thrust::device_vector<int>& seed_queryIDArray,
+		thrust::device_vector<int>& seed_queryIndexArray) {
+	time_attack::runLabeledWithSuffix(
+			"  ...deleting hits on sequence boundary", "....................finished.",
+			[&] {
+				removeSeedsOnSequenceBoundary(
+						s,
+						h,
+						q,
+						t_begin,
+						q_begin,
+						seed_targetIDArray,
+						seed_targetIndexArray,
+						seed_queryIDArray,
+						seed_queryIndexArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << seed_targetIDArray.size() << " hits found." << std::endl;
+			});
 	#ifdef MODE_TEST
 		CTest::printQueryToTarget(
 				seed_targetIDArray,

--- a/src/device/CDeviceHitList_sortSeeds.cu
+++ b/src/device/CDeviceHitList_sortSeeds.cu
@@ -2,10 +2,9 @@
 #include "device/CDeviceHitList_seed_host_api.cuh"
 
 #include "util/common.hpp"
+#include "util/time_attack.hpp"
 
-#ifdef TIME_ATTACK
-	#include <iostream>
-#endif
+#include <iostream>
 
 #ifdef MODE_TEST
 	#include "test_support/CTest.cuh"
@@ -16,36 +15,24 @@ void sortSeeds(
 		thrust::device_vector<int>& seed_targetIndexArray,
 		thrust::device_vector<int>& seed_queryIDArray,
 		thrust::device_vector<int>& seed_queryIndexArray) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...measure distance sorting";
-	#endif /* TIME_ATTACK */
-
-	measureDistanceSorting(
+	time_attack::runLabeledWithSuffix(
+			"  ...measure distance sorting",
+			"..............................finished.",
+			[&] {
+				measureDistanceSorting(
+						seed_targetIDArray,
+						seed_targetIndexArray,
+						seed_queryIDArray,
+						seed_queryIndexArray);
+			},
+			[&](std::ostream& os, float /*ms*/) {
+				os << seed_targetIDArray.size() << " hits found." << std::endl;
+			});
+#ifdef MODE_TEST
+	CTest::printQueryToTarget(
 			seed_targetIDArray,
 			seed_targetIndexArray,
 			seed_queryIDArray,
 			seed_queryIndexArray);
-
-	#ifdef TIME_ATTACK
-		std::cout << "..............................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout
-				<< " (costs " << elapsed_time_ms << "ms) "
-				<< seed_targetIDArray.size() << " hits found."
-				<< std::endl;
-	#endif /* TIME_ATTACK */
-	#ifdef MODE_TEST
-		CTest::printQueryToTarget(
-				seed_targetIDArray,
-				seed_targetIndexArray,
-				seed_queryIDArray,
-				seed_queryIndexArray);
-	#endif /* MODE_TEST */
+#endif
 }

--- a/src/host/CHostMapper.cu
+++ b/src/host/CHostMapper.cu
@@ -3,69 +3,27 @@
 #include "host/CHostSchedular.cuh"
 
 #include "util/common.hpp"
+#include "util/time_attack.hpp"
 
 #include <iostream>
 
 CHostMapper::CHostMapper(const CHostSetting& s) : setting(s) {}
 
 void CHostMapper::addTarget(const std::vector<CHostFASTA>& t) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "...Preparing target on host";
-	#endif /* TIME_ATTACK */
-
-	targetList.add(setting, t);
-
-	#ifdef TIME_ATTACK
-		std::cout << "..finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout << " (costs " << elapsed_time_ms << "ms)" << std::endl;
-	#endif /* TIME_ATTACK */
+	time_attack::runLabeled(
+			"...Preparing target on host", "..finished.",
+			[&] { targetList.add(setting, t); });
 }
 
 void CHostMapper::addQuery(const std::vector<CHostFASTA>& q) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "...Preparing query on host";
-	#endif /* TIME_ATTACK */
-
-	queryList.add(setting, q);
-
-	#ifdef TIME_ATTACK
-		std::cout << "...finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout << " (costs " << elapsed_time_ms << "ms)" << std::endl;
-	#endif /* TIME_ATTACK */
+	time_attack::runLabeled(
+			"...Preparing query on host", "...finished.",
+			[&] { queryList.add(setting, q); });
 }
 
 void CHostMapper::getResult(CHostResultHolder& holder) const {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-	#endif /* TIME_ATTACK */
-
+	time_attack::runEndSeconds([&] {
 	CHostSchedular schedular(setting, targetList, queryList);
 	schedular.search(holder);
-
-	#ifdef TIME_ATTACK
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout << "...costs " << elapsed_time_ms/1000 << "seconds" << std::endl;
-	#endif /* TIME_ATTACK */
+	});
 }

--- a/src/host/CHostResultHolder.cu
+++ b/src/host/CHostResultHolder.cu
@@ -1,6 +1,7 @@
 #include "host/CHostResultHolder.cuh"
 
 #include "util/utilResultSorting.cuh"
+#include "util/time_attack.hpp"
 
 #include <thrust/host_vector.h>
 #include <cstdlib>
@@ -90,32 +91,21 @@ void CHostResultHolder::fixResult  (void) {
 	// See also: addLabel() and addStartIdx()
 	sequence(d_targetIDArray.begin(), d_targetIDArray.end());
 
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << std::endl << "  ...sorting results";
-	#endif /* TIME_ATTACK */
-	resultSorting(
-			d_targetIDArray,
-			d_targetIndexArray,
-			d_queryIDArray,
-			d_queryIndexArray,
-			d_tHitLengthArray,
-			d_qHitLengthArray,
-			d_matchNumArray,
-			d_scoreArray,
-			d_evalueArray);
-	#ifdef TIME_ATTACK
-		std::cout << ".......................................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout
-				<< " (costs " << elapsed_time_ms << "ms)";
-	#endif /* TIME_ATTACK */
+	time_attack::runLabeled(
+			"\n  ...sorting results", ".......................................finished.",
+			[&] {
+				resultSorting(
+						d_targetIDArray,
+						d_targetIndexArray,
+						d_queryIDArray,
+						d_queryIndexArray,
+						d_tHitLengthArray,
+						d_qHitLengthArray,
+						d_matchNumArray,
+						d_scoreArray,
+						d_evalueArray);
+			},
+			time_attack::NewlineAfterCosts::No);
 
 	targetIDArray    = d_targetIDArray;
 	targetIndexArray = d_targetIndexArray;
@@ -129,17 +119,9 @@ void CHostResultHolder::fixResult  (void) {
 }
 
 /* called at main() after CHostSchedular::search() was called */
-void CHostResultHolder::printResult(
-		const int numberOfOutput,
+void CHostResultHolder::printResultToFile(
+		int numberOfOutput,
 		const std::string& outputFile) const {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		cudaEventCreate( &start );
-		cudaEventCreate( &stop  );
-		cudaEventRecord( start, 0 );
-		std::cout << "  ...print result to disc";
-	#endif /* TIME_ATTACK */
 	std::stringstream filename;
 	filename << outputFile;
 
@@ -233,12 +215,12 @@ void CHostResultHolder::printResult(
 		}
 	}
 	std::cout << " " << printedHitsCounter << " hits has printed." << std::endl;
+}
 
-	#ifdef TIME_ATTACK
-		std::cout << "..................................finished.";
-		cudaEventRecord( stop, 0 );
-		cudaEventSynchronize( stop );
-		cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-		std::cout << " (costs " << elapsed_time_ms << "ms)" << std::endl;
-	#endif /* TIME_ATTACK */
+void CHostResultHolder::printResult(
+		const int numberOfOutput,
+		const std::string& outputFile) const {
+	time_attack::runLabeled(
+			"  ...print result to disc", "..................................finished.",
+			[&] { printResultToFile(numberOfOutput, outputFile); });
 }

--- a/src/host/CHostResultHolder.cuh
+++ b/src/host/CHostResultHolder.cuh
@@ -41,6 +41,10 @@ public:
 	void printResult(
 			const int numberOfOutput,
 			const std::string& outputFile) const;
+private:
+	void printResultToFile(
+			int numberOfOutput,
+			const std::string& outputFile) const;
 };
 
 #endif

--- a/src/host/CHostSchedular.cu
+++ b/src/host/CHostSchedular.cu
@@ -1,13 +1,14 @@
 #include "host/CHostSchedular.cuh"
 
 #include "util/common.hpp"
+#include "util/time_attack.hpp"
 
 #include "device/CDeviceHashTable.cuh"
 #include "device/CDeviceHitList.cuh"
 #include "device/CDeviceSeqList_query.cuh"
 
 #include <iostream>
-#include <sstream>
+#include <memory>
 
 void moveQueryWindow(
 		const CHostSeqList_query& queryList,
@@ -41,16 +42,10 @@ CHostSchedular::CHostSchedular(
 		: setting(s), targetList(t), queryList(q) {}
 
 void CHostSchedular::search(CHostResultHolder& holder) {
-	#ifdef TIME_ATTACK
-		float elapsed_time_ms=0.0f;
-		cudaEvent_t start, stop;
-		std::cout << std::endl << "...Searching." << std::endl;
-	#endif /* TIME_ATTACK */
+	time_attack::print_searching_banner();
 
 	/* scheduling(target) */
-	#ifdef TIME_ATTACK
-		int searchTimes_target = 0;
-	#endif
+	[[maybe_unused]] int searchTimes_target = 0;
 	const int tEndID = targetList.getGatewaySize() - 1;
 	for(int t_begin = 0, t_end = 1; t_begin < tEndID; t_begin = t_end++) {
 		moveTargetWindow(
@@ -59,27 +54,18 @@ void CHostSchedular::search(CHostResultHolder& holder) {
 				tEndID,
 				t_begin,
 				t_end);
-		#ifdef TIME_ATTACK
-			cudaEventCreate( &start );
-			cudaEventCreate( &stop  );
-			cudaEventRecord( start, 0 );
-			std::cout
-					<< " Creating hash table [" << searchTimes_target++ << "]"
-					<< " (t_begin/t_end -> " << t_begin << "/" << t_end << ") ";
-		#endif /* TIME_ATTACK */
-		CDeviceHashTable  hashTable(setting, targetList, t_begin, t_end);
-		#ifdef TIME_ATTACK
-			std::cout << "...finished." << std::endl;
-			cudaEventRecord( stop, 0 );
-			cudaEventSynchronize( stop );
-			cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-			std::cout << " (costs " << elapsed_time_ms << "ms)" << std::endl;
-		#endif /* TIME_ATTACK */
+		std::unique_ptr<CDeviceHashTable> pHash;
+		time_attack::runLabeledPrefix(
+				[&, t_begin, t_end](std::ostream& os) {
+					os << " Creating hash table [" << searchTimes_target++ << "]"
+					   << " (t_begin/t_end -> " << t_begin << "/" << t_end << ") ";
+				},
+				"...finished.\n",
+				[&] { pHash = std::make_unique<CDeviceHashTable>(setting, targetList, t_begin, t_end); });
+		CDeviceHashTable& hashTable = *pHash;
 
 		/* scheduling(query) */
-		#ifdef TIME_ATTACK
-			int searchTimes_query = 0;
-		#endif
+		[[maybe_unused]] int searchTimes_query = 0;
 		// this magic number 2 = number of query strand types ('+', '-')
 		const int qEndID = (queryList.getGatewaySize()-1)/2;
 		for(int q_begin = 0, q_end = 1; q_begin < qEndID; q_begin = q_end++) {
@@ -89,38 +75,27 @@ void CHostSchedular::search(CHostResultHolder& holder) {
 					qEndID,
 					q_begin,
 					q_end);
-			#ifdef TIME_ATTACK
-				cudaEventCreate( &start );
-				cudaEventCreate( &stop  );
-				cudaEventRecord( start, 0 );
-				std::cout << std::endl << "  ...Transferring queries from host to device";
-			#endif /* TIME_ATTACK */
-			CDeviceSeqList_query deviceQueryList(setting, &queryList, q_begin, q_end);
-			#ifdef TIME_ATTACK
-				std::cout << "..............finished.";
-				cudaEventRecord( stop, 0 );
-				cudaEventSynchronize( stop );
-				cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-				std::cout << " (costs " << elapsed_time_ms << "ms)" << std::endl;
-			#endif /* TIME_ATTACK */
+			std::unique_ptr<CDeviceSeqList_query> pQuery;
+			time_attack::runLabeledPrefix(
+					[](std::ostream& os) { os << std::endl << "  ...Transferring queries from host to device"; },
+					"..............finished.",
+					[&] {
+						pQuery = std::make_unique<CDeviceSeqList_query>(setting, &queryList, q_begin, q_end);
+					});
+			CDeviceSeqList_query& deviceQueryList = *pQuery;
 
-			#ifdef TIME_ATTACK
-				cudaEventCreate( &start );
-				cudaEventCreate( &stop  );
-				cudaEventRecord( start, 0 );
-				std::cout
-						<< " Creating hit list   [" << searchTimes_query++ << "]"
-						<< " (q_begin/q_end -> " << q_begin << "/" << q_end << ") ";
-			#endif /* TIME_ATTACK */
-			// this magic number 2 = number of query strand types ('+', '-')
-			CDeviceHitList hitList(setting, hashTable, deviceQueryList, t_begin, q_begin*2);
-			#ifdef TIME_ATTACK
-				std::cout << "...finished." << std::endl;
-				cudaEventRecord( stop, 0 );
-				cudaEventSynchronize( stop );
-				cudaEventElapsedTime( &elapsed_time_ms, start, stop );
-				std::cout << " (costs " << elapsed_time_ms << "ms)" << std::endl;
-			#endif /* TIME_ATTACK */
+			std::unique_ptr<CDeviceHitList> pHit;
+			time_attack::runLabeledPrefix(
+					[&, q_begin, q_end](std::ostream& os) {
+						os << " Creating hit list   [" << searchTimes_query++ << "]"
+						   << " (q_begin/q_end -> " << q_begin << "/" << q_end << ") ";
+					},
+					"...finished.\n",
+					[&] {
+						// this magic number 2 = number of query strand types ('+', '-')
+						pHit = std::make_unique<CDeviceHitList>(setting, hashTable, deviceQueryList, t_begin, q_begin*2);
+					});
+			CDeviceHitList& hitList = *pHit;
 
 			hitList.getResult(holder); // this subroutine calls holder::addResult().
 			holder.addLabel   (targetList);

--- a/src/util/common.hpp
+++ b/src/util/common.hpp
@@ -3,7 +3,8 @@
 
 /* If you want to run in test or time-attack mode,
  * only you have to do is to comment-in this definition.
- *
+ * Alternatively, configure CMake with -DCLAST_ENABLE_TIME_ATTACK=ON
+ * to define TIME_ATTACK for the clast target (no edit here).
  */
 //#define MODE_TEST
 //#define TIME_ATTACK

--- a/src/util/time_attack.hpp
+++ b/src/util/time_attack.hpp
@@ -1,0 +1,157 @@
+#ifndef TIME_ATTACK_HPP_
+#define TIME_ATTACK_HPP_
+
+#include "util/common.hpp"
+
+#include <string_view>
+#include <utility>
+#ifdef TIME_ATTACK
+#include <cuda_runtime.h>
+#include <iostream>
+#include <ostream>
+#endif
+
+namespace time_attack {
+
+/* Whether to append std::endl after the "(costs X ms)" line (when there is no extra tail). */
+enum class NewlineAfterCosts { Yes, No };
+
+#ifdef TIME_ATTACK
+inline void print_searching_banner() {
+  std::cout << std::endl << "...Searching." << std::endl;
+}
+#else
+inline void print_searching_banner() {
+}
+#endif
+
+#ifdef TIME_ATTACK
+
+namespace detail {
+
+struct CudaEventPair {
+  cudaEvent_t start_{}, stop_{};
+
+  CudaEventPair() {
+    cudaEventCreate(&start_);
+    cudaEventCreate(&stop_);
+  }
+  CudaEventPair(const CudaEventPair&) = delete;
+  CudaEventPair& operator=(const CudaEventPair&) = delete;
+
+  void recordStart() { cudaEventRecord(start_, 0); }
+  float recordStopAndElapsedMs() {
+    cudaEventRecord(stop_, 0);
+    cudaEventSynchronize(stop_);
+    float ms = 0.f;
+    cudaEventElapsedTime(&ms, start_, stop_);
+    return ms;
+  }
+  ~CudaEventPair() {
+    cudaEventDestroy(start_);
+    cudaEventDestroy(stop_);
+  }
+};
+
+}  // namespace detail
+
+/**
+ * Manual GPU timer for call sites that cannot use runLabeled (e.g. a local must be declared
+ * between "start" output and the end of the interval).
+ */
+using CudaEventTimer = detail::CudaEventPair;
+
+/** Start message as string, then f(), then between, then (costs X ms). */
+template <typename F>
+void runLabeled(std::string_view start,
+                std::string_view between,
+                F&& f,
+                NewlineAfterCosts nl = NewlineAfterCosts::Yes) {
+  detail::CudaEventPair ev;
+  ev.recordStart();
+  std::cout << start;
+  f();
+  std::cout << between;
+  const float ms = ev.recordStopAndElapsedMs();
+  std::cout << " (costs " << ms << "ms)";
+  if (nl == NewlineAfterCosts::Yes) {
+    std::cout << std::endl;
+  }
+}
+
+/** Dynamic start line via void(ostream&), then f(), then string between, then (costs). */
+template <typename P, typename F>
+void runLabeledPrefix(P&& printStart, std::string_view between, F&& f,
+                      NewlineAfterCosts nl = NewlineAfterCosts::Yes) {
+  detail::CudaEventPair ev;
+  ev.recordStart();
+  printStart(std::cout);
+  f();
+  std::cout << between;
+  const float ms = ev.recordStopAndElapsedMs();
+  std::cout << " (costs " << ms << "ms)";
+  if (nl == NewlineAfterCosts::Yes) {
+    std::cout << std::endl;
+  }
+}
+
+/**
+ * (costs X ms) then afterCosts(ostream, ms) for suffix like "N hits found." + endl.
+ */
+template <typename F, typename T>
+void runLabeledWithSuffix(std::string_view start,
+                          std::string_view between,
+                          F&& f,
+                          T&& afterCosts) {
+  detail::CudaEventPair ev;
+  ev.recordStart();
+  std::cout << start;
+  f();
+  std::cout << between;
+  const float ms = ev.recordStopAndElapsedMs();
+  std::cout << " (costs " << ms << "ms) ";
+  afterCosts(std::cout, ms);
+}
+
+/** No start line: record, f(), then ...costs X seconds. */
+template <typename F>
+void runEndSeconds(F&& f) {
+  detail::CudaEventPair ev;
+  ev.recordStart();
+  f();
+  const float ms = ev.recordStopAndElapsedMs();
+  std::cout << "...costs " << (ms / 1000.0) << "seconds" << std::endl;
+}
+
+#else  // !TIME_ATTACK
+
+struct CudaEventTimer {
+  void recordStart() {}
+  float recordStopAndElapsedMs() { return 0.f; }
+};
+
+template <typename F>
+void runLabeled(std::string_view, std::string_view, F&& f, NewlineAfterCosts = NewlineAfterCosts::Yes) {
+  std::forward<F>(f)();
+}
+
+template <typename P, typename F>
+void runLabeledPrefix(P&&, std::string_view, F&& f, NewlineAfterCosts = NewlineAfterCosts::Yes) {
+  std::forward<F>(f)();
+}
+
+template <typename F, typename T>
+void runLabeledWithSuffix(std::string_view, std::string_view, F&& f, T&&) {
+  std::forward<F>(f)();
+}
+
+template <typename F>
+void runEndSeconds(F&& f) {
+  std::forward<F>(f)();
+}
+
+#endif  // TIME_ATTACK
+
+}  // namespace time_attack
+
+#endif  // TIME_ATTACK_HPP_


### PR DESCRIPTION
- Centralize timing/label helpers; add CLAST_ENABLE_TIME_ATTACK CMake option and document in common.hpp.

- Refactor host/device code paths to use time_attack:: helpers; fix resultSorting call in CDeviceHitList.cu.

- Docker: docker-common.sh, Windows Git Bash path/cygpath/MSYS fixes, PowerShell wrappers, README updates.

Made-with: Cursor